### PR TITLE
Add Battle.Net Services

### DIFF
--- a/src/OAuth2/Service/BattleNetBase.php
+++ b/src/OAuth2/Service/BattleNetBase.php
@@ -1,0 +1,87 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\OAuth2\Token\StdOAuth2Token;
+use OAuth\Common\Http\Exception\TokenResponseException;
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetBase extends AbstractService
+{
+    /**
+	 * Scopes
+	 *
+	 * @var string
+	 */
+
+    const SCOPE_WOW_PROFILE				= 'wow.profile';
+    const SCOPE_SC2_PROFILE				= 'sc2.profile';
+
+    /**
+     * BattleNet Region
+     *
+     * @var string
+     */
+    protected $region;
+
+    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+    {
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        if ( null === $baseApiUri ) {
+    	    $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+    	}
+    }
+
+    /**
+     * @return \OAuth\Common\Http\Uri\UriInterface
+     */
+    public function getAuthorizationEndpoint()
+    {
+        return new Uri('https://' . $this->region . '.battle.net/oauth/authorize');
+   	}
+
+    /**
+     * @return \OAuth\Common\Http\Uri\UriInterface
+     */
+    public function getAccessTokenEndpoint()
+    {
+        return new Uri('https://' . $this->region . '.battle.net/oauth/token');
+    }
+
+   	/**
+   	 * @param string $responseBody
+   	 * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
+   	 * @throws \OAuth\Common\Http\Exception\TokenResponseException
+   	 */
+   	protected function parseAccessTokenResponse($responseBody)
+   	{
+   	    $data = json_decode( $responseBody, true );
+
+   	    if( null === $data || !is_array($data) ) {
+   	        throw new TokenResponseException('Unable to parse response.');
+   	    } elseif( isset($data['error'] ) ) {
+   	        throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
+   	    }
+
+   	    $token = new StdOAuth2Token();
+
+   	    $token->setAccessToken( $data['access_token'] );
+   	    // I'm invincible!!!
+   	    $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
+   	    unset( $data['access_token'] );
+   	    $token->setExtraParams( $data );
+
+   	    return $token;
+   	}
+
+   	/**
+   	 * @return int
+   	 */
+   	protected function getAuthorizationMethod()
+   	{
+   	    return static::AUTHORIZATION_METHOD_QUERY_STRING;
+   	}
+}

--- a/src/OAuth2/Service/BattleNetCN.php
+++ b/src/OAuth2/Service/BattleNetCN.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetCN extends BattleNetBase
+{
+    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+   	{
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        $this->region = 'cn';
+        $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+    }
+}

--- a/src/OAuth2/Service/BattleNetEU.php
+++ b/src/OAuth2/Service/BattleNetEU.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetEU extends BattleNetBase
+{
+    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+   	{
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        $this->region = 'eu';
+        $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+    }
+}

--- a/src/OAuth2/Service/BattleNetKR.php
+++ b/src/OAuth2/Service/BattleNetKR.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetKR extends BattleNetBase
+{
+    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+    {
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        $this->region = 'kr';
+        $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+	}
+}

--- a/src/OAuth2/Service/BattleNetTW.php
+++ b/src/OAuth2/Service/BattleNetTW.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetTW extends BattleNetBase
+{
+    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+   	{
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        $this->region = 'tw';
+        $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+	}
+}

--- a/src/OAuth2/Service/BattleNetUS.php
+++ b/src/OAuth2/Service/BattleNetUS.php
@@ -1,0 +1,18 @@
+<?php
+namespace OAuth\OAuth2\Service;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+
+class BattleNetUS extends BattleNetBase
+{
+	public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
+   	{
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        $this->region = 'us';
+        $this->baseApiUri = new Uri('https://' . $this->region . '.api.battle.net/');
+    }
+}


### PR DESCRIPTION
This can probably be cleaned up a bit, but I wasn't sure how.  Each
region uses the same syntax and pattern, however all URIs have a
different sub-domain.  I implemented it as a base class and overrides
for the region, but ideally it should be a single class that can take a
region setting.  I wasn't sure how to tackle such a thing consistent
with the architectural objectives of the project though.
