### PR TITLE
Allow string arguments for the $body parameter in httpRequest

### DIFF
--- a/src/Common/Service/AbstractService.php
+++ b/src/Common/Service/AbstractService.php
@@ -162,7 +162,7 @@ abstract class AbstractService implements ServiceInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function requestJSON($uri, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function requestJSON($uri, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		return json_decode($this->request($uri, $body, $method, $extraHeaders), TRUE);
 	}
@@ -170,11 +170,18 @@ abstract class AbstractService implements ServiceInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function httpRequest($uri, array $body = [], array $headers = [], $method = 'POST')
+	public function httpRequest($uri, $body = [], array $headers = [], $method = 'POST')
 	{
 		try
 		{
-			$response = $this->httpTransporter->submit($uri, $body, $method, $headers);
+			if (is_array($body))
+			{
+				$response = $this->httpTransporter->submit($uri, $body, $method, $headers);
+			} else
+			{
+				$response = $this->httpTransporter->call($uri, $method, $headers, $body);
+			}
+
 		} catch (RequestException $e)
 		{
 			throw new TokenResponseException($e->getMessage() ? $e->getMessage() : 'Failed to request resource.');

--- a/src/Common/Service/ServiceInterface.php
+++ b/src/Common/Service/ServiceInterface.php
@@ -17,38 +17,37 @@ interface ServiceInterface {
 	 * If the path provided is not an absolute URI, the base API Uri (service-specific) will be used.
 	 *
 	 * @param string|Url $path
-	 * @param array $body Request body if applicable (an associative array will
+	 * @param array|string $body Request body if applicable (an associative array will automatically be converted into a urlencoded body)
 	 * @param string $method HTTP method
-	 *                                          automatically be converted into a urlencoded body)
-	 * @param array $extraHeaders Extra headers if applicable. These will override service-specific
-	 *                                          any defaults.
+	 *
+	 * @param array $extraHeaders Extra headers if applicable. These will override service-specific defaults.
 	 * @return string
 	 */
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = []);
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = []);
 
 	/**
 	 * Shortcut for json_decode($this->request(...
 	 *
 	 * @param $uri
-	 * @param array $body
+	 * @param array|string $body
 	 * @param string $method
 	 * @param array $extraHeaders
 	 * @return array
 	 */
-	public function requestJSON($uri, array $body = [], $method = 'GET', array $extraHeaders = []);
+	public function requestJSON($uri, $body = [], $method = 'GET', array $extraHeaders = []);
 
 	/**
 	 * Sends an authenticated API request to the path provided.
 	 * If the path provided is not an absolute URI, the base API Uri (must be passed into constructor) will be used.
 	 *
 	 * @param Url|string $uri
-	 * @param array $body Request body if applicable (key/value pairs)
+	 * @param array|string $body Request body if applicable
 	 * @param array $headers Extra headers if applicable.
 	 * @param string $method HTTP method
 	 * @throws TokenResponseException
 	 * @return string
 	 */
-	public function httpRequest($uri, array $body = [], array $headers = [], $method = 'POST');
+	public function httpRequest($uri, $body = [], array $headers = [], $method = 'POST');
 
 	/**
 	 * Returns the url to redirect to for authorization purposes.

--- a/src/OAuth1/Service/AbstractService.php
+++ b/src/OAuth1/Service/AbstractService.php
@@ -130,7 +130,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
 	/**
 	 * {@inheritdoc}
 	 */
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		$uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
 

--- a/src/OAuth1/Service/Flickr.php
+++ b/src/OAuth1/Service/Flickr.php
@@ -74,7 +74,7 @@ class Flickr extends AbstractService {
 		return $token;
 	}
 
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		$uri = $this->determineRequestUriFromPath('/');
 		$uri->getQuery()->modify(['method' => $path]);

--- a/src/OAuth2/Service/AbstractService.php
+++ b/src/OAuth2/Service/AbstractService.php
@@ -134,7 +134,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
 	 * @throws ExpiredTokenException
 	 * @throws Exception
 	 */
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		$uri   = $this->determineRequestUriFromPath($path);
 		$token = $this->storage->retrieveAccessToken($this->service());

--- a/src/OAuth2/Service/Foursquare.php
+++ b/src/OAuth2/Service/Foursquare.php
@@ -43,7 +43,7 @@ class Foursquare extends AbstractService {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		$uri = $this->determineRequestUriFromPath($path);
 		$uri->getQuery()->modify(['v' => $this->apiVersionDate]);

--- a/src/OAuth2/Service/Mailchimp.php
+++ b/src/OAuth2/Service/Mailchimp.php
@@ -55,7 +55,7 @@ class Mailchimp extends AbstractService {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+	public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
 	{
 		if (is_null($this->baseApiUri))
 		{

--- a/tests/Mocks/Common/Service/Mock.php
+++ b/tests/Mocks/Common/Service/Mock.php
@@ -23,7 +23,7 @@ class Mock extends AbstractService
 	/**
      * {@inheritdoc}
      */
-    public function request($path, array $body = [], $method = 'GET', array $extraHeaders = [])
+    public function request($path, $body = [], $method = 'GET', array $extraHeaders = [])
     {
     }
 

--- a/tests/Mocks/OAuth1/Service/Mock.php
+++ b/tests/Mocks/OAuth1/Service/Mock.php
@@ -12,7 +12,7 @@ class Mock extends AbstractService
 	protected $authorizationEndpoint = 'http://pieterhordijk.com/auth';
 	protected $accessTokenEndpoint = 'http://pieterhordijk.com/access';
 
-	public function httpRequest($uri, array $body = [], array $headers = [], $method = 'POST')
+	public function httpRequest($uri, $body = [], array $headers = [], $method = 'POST')
 	{
 		return [
 			'uri' => $uri,

--- a/tests/Mocks/OAuth2/Service/Mock.php
+++ b/tests/Mocks/OAuth2/Service/Mock.php
@@ -25,7 +25,7 @@ class Mock extends AbstractService
         $this->authorizationMethod = $method;
     }
 
-	public function httpRequest($uri, array $body = [], array $headers = [], $method = 'POST')
+	public function httpRequest($uri, $body = [], array $headers = [], $method = 'POST')
 	{
 		return [
 			'uri' => $uri,


### PR DESCRIPTION
This pull request aims to resolve #21 by allowing string data to be used in the request body as an alternative to array and form data.
