### PR TITLE
Fix double slash in path

### DIFF
--- a/src/Common/Service/AbstractService.php
+++ b/src/Common/Service/AbstractService.php
@@ -132,7 +132,7 @@ abstract class AbstractService implements ServiceInterface
                 $path = substr($path, 1);
             }
 
-            $uri->setPath($uri->getPath() . '/' . $path);
+            $uri->setPath(rtrim($uri->getPath(), '/') . '/' . $path);
         }
 
         return $uri;


### PR DESCRIPTION
I am using the Spotify service. When I execute:

``` php
$service->requestJSON('me'))
```

The service is trying to call "v1//me". This isn't a valid path. This PR fixes the double slash.

Can you please tag this version
