### PR TITLE
Fixed double slash in uri base path. Also fixed unit testing related to double slash

### DIFF
--- a/src/Common/Service/AbstractService.php
+++ b/src/Common/Service/AbstractService.php
@@ -132,7 +132,7 @@ abstract class AbstractService implements ServiceInterface
                 $path = substr($path, 1);
             }
 
-            $uri->setPath($uri->getPath() . '/' . $path);
+            $uri->setPath(rtrim($uri->getPath(), '/') . '/' . $path);
         }
 
         return $uri;

--- a/tests/Unit/OAuth2/Service/DeviantArtTest.php
+++ b/tests/Unit/OAuth2/Service/DeviantArtTest.php
@@ -77,7 +77,7 @@ class DeviantArtTest extends \PHPUnit_Framework_TestCase
         $service->expects($this->once())->method('httpRequest')->willReturnArgument(0);
 
         $this->assertEquals(
-            'https://www.deviantart.com/api/v1/oauth2//api/method',
+            'https://www.deviantart.com/api/v1/oauth2/api/method',
             (string) $service->request('/api/method')
         );
     }


### PR DESCRIPTION
This pull request fixes double slash in the uri base path of all services. This also includes fixes in the unit test related to the double slash.

Credits also to @trsteel88  
