### PR TITLE
Fix problems with raw email arrays from Github

### DIFF
--- a/src/UserData/Extractor/GitHub.php
+++ b/src/UserData/Extractor/GitHub.php
@@ -98,14 +98,14 @@ class GitHub extends LazyExtractor
     {
         $email = $this->getEmailObject($emails);
 
-        return $email[ 'email' ];
+        return is_array($email) ? $email[ 'email' ] : $email;
     }
 
     protected function verifiedEmailNormalizer($emails)
     {
         $email = $this->getEmailObject($emails);
 
-        return $email[ 'verified' ];
+        return array_key_exists('verified', $email) ? $email[ 'verified' ] : false;
     }
 
     /**


### PR DESCRIPTION
I have problem with Github Extractor and `getEmail()` this function returns only first character of first email.

```
array (
  0 => "abcde@omdesign.cz"
  1 => "abcd@gmail.com"
  2 => "abcdef@eee.com"
)
```

Look on https://github.com/logical-and/php-oauth/blob/master/examples/github.php#L40 works well, but new version of API an extractors counting with wider structure.

https://developer.github.com/v3/media/ 
