### PR TITLE
Fix problems with raw email arrays from Github

### DIFF
--- a/examples/github.php
+++ b/examples/github.php
@@ -40,7 +40,7 @@ if ($gitHub->isGlobalRequestArgumentsPassed()) {
     $result = $gitHub->retrieveAccessTokenByGlobReqArgs()->requestJSON('user/emails');
 
     // Show some of the resultant data
-    echo 'The first email on your github account is ' . $result[ 0 ];
+    echo 'The first email on your github account is ' . $result[ 0 ][ 'email' ];
 
     echo '<br />';
     echo 'Your extracted username is a: ' . $gitHub->constructExtractor()->getUsername();

--- a/src/OAuth2/Service/GitHub.php
+++ b/src/OAuth2/Service/GitHub.php
@@ -124,7 +124,7 @@ class GitHub extends AbstractService
     protected $authorizationMethod = self::AUTHORIZATION_METHOD_QUERY_STRING;
     protected $extraOAuthHeaders = ['Accept' => 'application/json'];
     protected $extraApiHeaders = [
-        'Accept'     => 'application/vnd.github.beta+json',
+        'Accept'     => 'application/vnd.github.v3+json',
         'User-Agent' => 'and/oauth-library'
     ];
 

--- a/tests/Unit/OAuth2/Service/GitHubTest.php
+++ b/tests/Unit/OAuth2/Service/GitHubTest.php
@@ -254,6 +254,6 @@ class GitHubTest extends \PHPUnit_Framework_TestCase
         $headers = $service->request('https://pieterhordijk.com/my/awesome/path');
 
         $this->assertTrue(array_key_exists('Accept', $headers));
-        $this->assertSame('application/vnd.github.beta+json', $headers[ 'Accept' ]);
+        $this->assertSame('application/vnd.github.v3+json', $headers[ 'Accept' ]);
     }
 }


### PR DESCRIPTION
I have problem with Github Extractor and `getEmail()` this function returns only first character of first email.

```
0 => "abcde@omdesign.cz"
1 => "abcd@gmail.com"
2 => "abcdef@eee.com"
```

Look on https://github.com/logical-and/php-oauth/blob/master/examples/github.php#L40 example have it right
