### PR TITLE
Fix for path not found with Tumblr

### DIFF
--- a/src/OAuth1/Service/Tumblr.php
+++ b/src/OAuth1/Service/Tumblr.php
@@ -8,7 +8,7 @@ use OAuth\OAuth1\Token\StdOAuth1Token;
 class Tumblr extends AbstractService
 {
 
-    protected $baseApiUri = 'https://api.tumblr.com/v2/';
+    protected $baseApiUri = 'https://api.tumblr.com/v2';
     protected $requestTokenEndpoint = 'https://www.tumblr.com/oauth/request_token';
     protected $authorizationEndpoint = 'https://www.tumblr.com/oauth/authorize';
     protected $accessTokenEndpoint = 'https://www.tumblr.com/oauth/access_token';


### PR DESCRIPTION
Hi,

I found that the extra / at the end of baseApiUri is now generating a Uri with // and ending with a "Not found" error.

BTW: Amazing package!

